### PR TITLE
Fixed commit history of official and stable releases

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ theme = 'openmodelica'
 
 [params]
   current_version = {release = '1.25.2', stable = '1.25.2', nightly = '1.26.0-dev'}
-  current_branch = {release = 'maintenance/v1.25', stable = 'maintenance/v1.25', nightly = 'master'}
+  current_branch = {release = 'v1.25.2', stable = 'v1.25.2', nightly = 'master'}
   bugreporting = 'https://github.com/OpenModelica/OpenModelica/blob/master/BUGREPORTING.md'
   roadmap = 'https://github.com/OpenModelica/OpenModelica/milestones'
 


### PR DESCRIPTION
Currently, the download pages have links to the maintenance branch, which is constantly updated towards the next patch release. This commit changes the links to point to the release tags