### PR TITLE
Fix Fedora 41+ repo command selection logic for dnf5 compatibility

### DIFF
--- a/content/download/download-linux.md
+++ b/content/download/download-linux.md
@@ -88,7 +88,12 @@ var selectedDebCodename = function() {
 };
 var selectedRpmCodename = function() {
   var codeNameValue=document.getElementById("rpm-codename-select").value;
-  var addRepoCommand=(codeNameValue=="fc41" ? "addrepo --from-repofile=" : "--add-repo ");
+  const match = codeNameValue.match(/\d+$/); 
+  const version = match ? parseInt(match[0], 10) : 0;
+  var addRepoCommand =
+  version >= 41
+    ? "addrepo --from-repofile="
+    : "--add-repo ";
   document.getElementById("rpm-os").innerHTML=codeNameValue;
   document.getElementById("rpm-os-add-repo-command").innerHTML=addRepoCommand;
   var codenameSelect = [];


### PR DESCRIPTION
All Fedora releases from version 41 onward use DNF5. Due to this, the `--add-repo <URL>` flag no longer works. This PR fixes the repo command selection logic so that it uses the new `--from-repofile=<URL>` flag for any Fedora version greater than or equal to 41.