### PR TITLE
Fix dnf5 syntax

### DIFF
--- a/content/download/download-linux.md
+++ b/content/download/download-linux.md
@@ -232,8 +232,10 @@ You can find the releases at https://build.openmodelica.org/omc/builds/linux/rel
 
 Starting with OpenModelica 1.9.4 you can use apt to download the packages using a deb-line such as the one below; make sure all existing OpenModelica packages have been uninstalled (so you do not end up with mismatching versions of dependencies):
 
-```text
-deb https://build.openmodelica.org/omc/builds/linux/releases/1.13.0/ bionic release
+```bash
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/omc/builds/linux/releases/1.25.5/ trixie release" > /etc/apt/sources.list.d/openmodelica.list
+sudo apt-get update
+sudo apt-get install omc
 ```
 
 ## RPM packages

--- a/content/download/download-linux.md
+++ b/content/download/download-linux.md
@@ -88,7 +88,7 @@ var selectedDebCodename = function() {
 };
 var selectedRpmCodename = function() {
   var codeNameValue=document.getElementById("rpm-codename-select").value;
-  var addRepoCommand=(codeNameValue=="fc41" ? "addrepo --from-repofile=" : "--add-repo ");
+  var addRepoCommand=(codeNameValue.startsWith("fc") && parseInt(codeNameValue.substring(2)) >= 41 ? "addrepo --from-repofile=" : "--add-repo ");
   document.getElementById("rpm-os").innerHTML=codeNameValue;
   document.getElementById("rpm-os-add-repo-command").innerHTML=addRepoCommand;
   var codenameSelect = [];

--- a/content/download/download-linux.md
+++ b/content/download/download-linux.md
@@ -209,7 +209,6 @@ There is a package manager for Modelica libraries built into the scripting inter
 
 If you install OpenModelica from a USB stick in a place without Internet access, for example during a tutorial at a conference, it is still possible to install the Modelica Standard Library.
 
-
 ```bash
 sudo apt install omlibrary
 ```
@@ -233,7 +232,10 @@ You can find the releases at https://build.openmodelica.org/omc/builds/linux/rel
 Starting with OpenModelica 1.9.4 you can use apt to download the packages using a deb-line such as the one below; make sure all existing OpenModelica packages have been uninstalled (so you do not end up with mismatching versions of dependencies):
 
 ```bash
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] https://build.openmodelica.org/omc/builds/linux/releases/1.25.5/ trixie release" > /etc/apt/sources.list.d/openmodelica.list
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] \
+  https://build.openmodelica.org/omc/builds/linux/releases/1.25.5/ \
+  $(cat /etc/os-release | grep "\(UBUNTU\|VERSION\)_CODENAME" | sort | cut -d= -f 2 | head -1) \
+  release" | sudo tee /etc/apt/sources.list.d/openmodelica.list
 sudo apt-get update
 sudo apt-get install omc
 ```


### PR DESCRIPTION
## Issue

Install instructions for newer fedora are wrong.

## Changes

* Update install instructions for older Linux release (changed GPG key)
* Update command for all Fedora versions >= 41

<img width="2693" height="683" alt="grafik" src="https://github.com/user-attachments/assets/88b79062-634f-4966-87b3-b10c23473854" />

## Approach

Tested with 

```bash
docker run --rm -it fedora:44 bash -c "
  dnf install -y 'dnf-command(config-manager)' &&
  dnf config-manager addrepo --from-repofile=https://build.openmodelica.org/rpm/fc44/omc.repo &&
  dnf install openmodelica-nightly &&
  omc --version
"

OpenModelica 1.28.0~dev
```

```bash
docker run --rm -it ubuntu:jammy bash -c "
  apt-get update &&
  apt-get install -y ca-certificates curl gnupg sudo &&
  curl -fsSL https://build.openmodelica.org/apt/openmodelica.asc | \
    gpg --dearmor -o /usr/share/keyrings/openmodelica-keyring.gpg &&
  echo \"deb [arch=\$(dpkg --print-architecture) signed-by=/usr/share/keyrings/openmodelica-keyring.gpg] \
    https://build.openmodelica.org/omc/builds/linux/releases/1.25.5/ \
    \$(cat /etc/os-release | grep '\(UBUNTU\|VERSION\)_CODENAME' | sort | cut -d= -f 2 | head -1) \
    release\" | sudo tee /etc/apt/sources.list.d/openmodelica.list &&
  sudo apt-get update &&
  sudo apt-get install -y omc &&
  omc --version
"

OpenModelica 1.25.5
```